### PR TITLE
kinship.loiselle: don't use && for indexing

### DIFF
--- a/R/GAPIT.kinship.loiselle.R
+++ b/R/GAPIT.kinship.loiselle.R
@@ -24,19 +24,19 @@ function(snps, method="additive", use="all") {
   #if(method == "additive").  Worry about this only if you have heterozygotes, which you do not.
   if( method == "dominant" ) {
     flags <- matrix(as.double(rowMeans(snps,na.rm=TRUE) > 0.5),nrow(snps),ncol(snps))
-    snps[!is.na(snps) && (snps == 0.5)] <- flags[!is.na(snps) && (snps == 0.5)]
+    snps[!is.na(snps) & (snps == 0.5)] <- flags[!is.na(snps) & (snps == 0.5)]
   }
   else if( method == "recessive" ) {
     flags <- matrix(as.double(rowMeans(snps,na.rm=TRUE) < 0.5),nrow(snps),ncol(snps))
-    snps[!is.na(snps) && (snps == 0.5)] <- flags[!is.na(snps) && (snps == 0.5)]
+    snps[!is.na(snps) & (snps == 0.5)] <- flags[!is.na(snps) & (snps == 0.5)]
   }
   else if( ( method == "additive" ) && ( nh > 0 ) ) {
     dsnps <- snps
     rsnps <- snps
     flags <- matrix(as.double(rowMeans(snps,na.rm=TRUE) > 0.5),nrow(snps),ncol(snps))
-    dsnps[!is.na(snps) && (snps==0.5)] <- flags[is.na(snps) && (snps==0.5)]
+    dsnps[!is.na(snps) & (snps==0.5)] <- flags[is.na(snps) & (snps==0.5)]
     flags <- matrix(as.double(rowMeans(snps,na.rm=TRUE) < 0.5),nrow(snps),ncol(snps))
-    rsnps[!is.na(snps) && (snps==0.5)] <- flags[is.na(snps) && (snps==0.5)]
+    rsnps[!is.na(snps) & (snps==0.5)] <- flags[is.na(snps) & (snps==0.5)]
     snps <- rbind(dsnps,rsnps)
   }
 

--- a/R/gapit_functions.R
+++ b/R/gapit_functions.R
@@ -12767,19 +12767,19 @@ function(snps, method="additive", use="all") {
   #if(method == "additive").  Worry about this only if you have heterozygotes, which you do not.
   if( method == "dominant" ) {
     flags <- matrix(as.double(rowMeans(snps,na.rm=TRUE) > 0.5),nrow(snps),ncol(snps))
-    snps[!is.na(snps) && (snps == 0.5)] <- flags[!is.na(snps) && (snps == 0.5)]
+    snps[!is.na(snps) & (snps == 0.5)] <- flags[!is.na(snps) & (snps == 0.5)]
   }
   else if( method == "recessive" ) {
     flags <- matrix(as.double(rowMeans(snps,na.rm=TRUE) < 0.5),nrow(snps),ncol(snps))
-    snps[!is.na(snps) && (snps == 0.5)] <- flags[!is.na(snps) && (snps == 0.5)]
+    snps[!is.na(snps) & (snps == 0.5)] <- flags[!is.na(snps) & (snps == 0.5)]
   }
   else if( ( method == "additive" ) && ( nh > 0 ) ) {
     dsnps <- snps
     rsnps <- snps
     flags <- matrix(as.double(rowMeans(snps,na.rm=TRUE) > 0.5),nrow(snps),ncol(snps))
-    dsnps[!is.na(snps) && (snps==0.5)] <- flags[is.na(snps) && (snps==0.5)]
+    dsnps[!is.na(snps) & (snps==0.5)] <- flags[is.na(snps) & (snps==0.5)]
     flags <- matrix(as.double(rowMeans(snps,na.rm=TRUE) < 0.5),nrow(snps),ncol(snps))
-    rsnps[!is.na(snps) && (snps==0.5)] <- flags[is.na(snps) && (snps==0.5)]
+    rsnps[!is.na(snps) & (snps==0.5)] <- flags[is.na(snps) & (snps==0.5)]
     snps <- rbind(dsnps,rsnps)
   }
 


### PR DESCRIPTION
I was just taking a look at the function for calculating the Loiselle kinship matrix since Dr. Lipka recommended that I try it out in a GWAS that I'm doing.  I happened to notice the use of `&&` in a way that looks like it was meant to be vectorized.  I expect it will cause problems however since `&&` only returns the first value within a logical vector.  (It is mostly intended to be used in `if` and `while` statements.)