### PR TITLE
changed test file package from GAPIT3documentation to GAPIT3

### DIFF
--- a/tests/testthat/test-GAPITfirst.R
+++ b/tests/testthat/test-GAPITfirst.R
@@ -9,9 +9,9 @@ test_that("multiplication works", {
 
 test_that("GAPIT mdp (Y and X) import works", {
   myPhenoFile <- system.file("extdata", "mdp_traits.txt.gz",
-                             package = "GAPIT3documentation")
+                             package = "GAPIT3")
   myGenoFile <- system.file("extdata", "mdp_genotype_test.hmp.txt.gz",
-                            package = "GAPIT3documentation")
+                            package = "GAPIT3")
 
   myPhenotypes <- read.table(myPhenoFile, header = TRUE)
   myGenotypes  <- read.table(myGenoFile, header = FALSE)
@@ -27,9 +27,9 @@ test_that("GAPIT mdp (Y and X) import works", {
 
 test_that("GAPIT wrapper works", {
   myPhenoFile <- system.file("extdata", "mdp_traits.txt.gz",
-                             package = "GAPIT3documentation")
+                             package = "GAPIT3")
   myGenoFile <- system.file("extdata", "mdp_genotype_test.hmp.txt.gz",
-                            package = "GAPIT3documentation")
+                            package = "GAPIT3")
 
   myPhenotypes <- read.table(myPhenoFile, header = TRUE)
   myGenotypes  <- read.table(myGenoFile, header = FALSE)


### PR DESCRIPTION
GAPIT3 currently throws an ERROR when testing it.

```
bash$ R CMD build GAPIT3
bash$ R CMD check GAPIT3_3.1.0.tar.gz
...
  ── Error (test-GAPITfirst.R:16:3): GAPIT mdp (Y and X) import works ────────────
  Error: no lines available in input
  Backtrace:
      █
   1. └─utils::read.table(myPhenoFile, header = TRUE) test-GAPITfirst.R:16:2
  ── Error (test-GAPITfirst.R:34:3): GAPIT wrapper works ─────────────────────────
  Error: no lines available in input
  Backtrace:
      █
   1. └─utils::read.table(myPhenoFile, header = TRUE) test-GAPITfirst.R:34:2
...
```

This is because the data testthat is looking for is in my "GAPIT3documentation" repo I made for my own testing (i.e., this is my fault). I've changed that here to point at "GAPIT3" instead and this appears to resolve the ERROR. Note that it uncovers a new ERROR related to `install.packages()` calls, but I feel this another issue.