### PR TITLE
Enable BLINK to work with 1 PC

### DIFF
--- a/R/GAPIT.RandomModel.R
+++ b/R/GAPIT.RandomModel.R
@@ -103,7 +103,7 @@ function(GWAS,Y,CV=NULL,X,cutOff=0.01,GT=NULL,name.of.trait=NULL,N.sig=NULL,n_ra
      # if(!is.null(PC))PC=PC[taxa_GD%in%taxa_Y,]
         Y=Y[taxa_Y%in%GT,]
         CV=CV[taxa_CV%in%GT,]
-    	tree2=cbind(Y,CV[,-1],geneGD)
+    	tree2=cbind(Y,CV[,-1,drop=FALSE],geneGD)
         }
     }
     if(in_True==1)colnames(tree2)[ncol(tree2)]=paste("gene_",1,sep="")


### PR DESCRIPTION
This commit fixes an error when running BLINK with 1 PC. 

Without this modification, running BLINK with PCA.total=1 results in the following error:
Error in eval(predvars, data, env) : object 'CV1' not found