### PR TITLE
Problem in GAPIT.Genotype.View.R

### DIFF
--- a/R/GAPIT.Genotype.R
+++ b/R/GAPIT.Genotype.R
@@ -628,7 +628,7 @@ ViewGenotype<-GAPIT.Genotype.View(
 GI=GI,
 X=GD,
 WS0=WS0,
-ws=ws,
+ws=ceiling(X/20),
 Aver.Dis=Aver.Dis
 )
 }

--- a/R/GAPIT.Genotype.R
+++ b/R/GAPIT.Genotype.R
@@ -628,7 +628,7 @@ ViewGenotype<-GAPIT.Genotype.View(
 GI=GI,
 X=GD,
 WS0=WS0,
-ws=ceiling(X/20),
+ws=ceiling(ncol(X)/20),
 Aver.Dis=Aver.Dis
 )
 }


### PR DESCRIPTION
In GAPIT.Genotype.View.R, in line 207, an error similar to ```Error in `[<-`(`*tmp*`, i, 1, value = 0) : subscript out of bounds``` happens if the variable ws is bigger than ncol(X) (e.g. number of SNPs). In order to avoid that error, I propose that ws should have a value that depends on ncol(X), for example, ```ws=ceiling(ncol(X)/20)```.